### PR TITLE
core/four-gray-display

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -29,6 +29,8 @@ if Gem.platforms.last.os == 'linux'
   Buttons.init unless Buttons.ready?
 end
 
+Inkblot.color_depth = 4 # 1
+
 ### EXAMPLE COMPONENTS
 
 ## SimpleText
@@ -76,6 +78,8 @@ end
   sc.fullscreen = true
   sc.items = (1..10).map { |x| "Option #{x}" }
 end
+
+@c = Converters::ImageConverter.new(input: 'tmp/cim.png')
 
 # Example button interaction scroll loop
 def test_scroll

--- a/bin/console
+++ b/bin/console
@@ -29,7 +29,7 @@ if Gem.platforms.last.os == 'linux'
   Buttons.init unless Buttons.ready?
 end
 
-Inkblot.color_depth = 4 # 1
+Inkblot.color_depth = 1 # 4
 
 ### EXAMPLE COMPONENTS
 
@@ -78,8 +78,6 @@ end
   sc.fullscreen = true
   sc.items = (1..10).map { |x| "Option #{x}" }
 end
-
-@c = Converters::ImageConverter.new(input: 'tmp/cim.png')
 
 # Example button interaction scroll loop
 def test_scroll

--- a/lib/inkblot.rb
+++ b/lib/inkblot.rb
@@ -7,6 +7,9 @@ require 'inkblot/components'
 
 # Ruby gem for interacting with waveshare e-Paper display
 module Inkblot
+
+  COLOR_DEPTH = [1, 4].freeze
+
   class << self
     # Returns the path to the vendor directory for this gem, to access non-ruby
     # assets like python code and html templates.
@@ -40,6 +43,20 @@ module Inkblot
     # Which pins are assigned to which of the four buttons, from top down
     def button_pinout
       @button_pinout ||= [5, 6, 13, 19].freeze
+    end
+
+    # Whether we use 2-bit or 4-bit color
+    def color_depth
+      @color_depth ||= 1
+    end
+
+    # Sets the +new_depth+ if it's in range
+    def color_depth=(new_depth)
+      unless COLOR_DEPTH.include?(new_depth)
+        raise ArgumentError, "Unsupported depth '#{new_depth}'" 
+      end
+
+      @color_depth = new_depth
     end
 
     private

--- a/lib/inkblot/converters/image_converter.rb
+++ b/lib/inkblot/converters/image_converter.rb
@@ -26,7 +26,7 @@ module Inkblot
         end
 
         resize(img_file)
-        mono2(img_file)
+        mono(img_file)
         img_file
       end
 
@@ -40,12 +40,12 @@ module Inkblot
 
       private
 
-      # 2Channel monochrome conversion of image
-      def mono2(img)
+      # Monochromatic representation of image
+      def mono(img)
         MiniMagick::Tool::Convert.new do |m|
           m << img.path
-          m.depth(1)
-          m.monochrome
+          m.colorspace('Gray')
+          m.depth(Inkblot.color_depth)
           m << ('bmp3:' << img.path)
         end
       end

--- a/lib/inkblot/converters/image_converter.rb
+++ b/lib/inkblot/converters/image_converter.rb
@@ -30,6 +30,14 @@ module Inkblot
         img_file
       end
 
+      # Saves the converted image permanently to path. 
+      # Converts if this has not been done
+      def save(path)
+        File.open(path, 'w+b') do |f|
+          f << File.read(output.path)
+        end
+      end
+
       private
 
       # 2Channel monochrome conversion of image

--- a/lib/inkblot/display.rb
+++ b/lib/inkblot/display.rb
@@ -78,7 +78,14 @@ module Inkblot
       # Takes in an image +img+ to display on the device.
       # Can be a File, filepath string, or a Converter subclass
       def image(img)
-        `#{pyscript('display', img)}`
+        disp_script = case Inkblot.color_depth
+                      when 1
+                        'display'
+                      when 4
+                        'display_4gray'
+                      end
+
+        `#{pyscript(disp_script, img)}`
       end
 
       # Create a python script string. +skript+ is the script's name

--- a/lib/inkblot/display.rb
+++ b/lib/inkblot/display.rb
@@ -76,7 +76,8 @@ module Inkblot
       private
 
       # Takes in an image +img+ to display on the device.
-      # Can be a File, filepath string, or a Converter subclass
+      # Can be a File, filepath string, or a Converter subclass.
+      # Automatically switches display script based on color depth 
       def image(img)
         disp_script = case Inkblot.color_depth
                       when 1

--- a/vendor/display_4gray.py
+++ b/vendor/display_4gray.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# -*- coding:utf-8 -*-
+import sys
+import os
+
+# The path to the gem library, passed in from ruby
+gpath = sys.argv[1]
+# The path to the image to display passed in from ruby
+imgpath = sys.argv[2]
+
+# Compose the path to the support library for the eink screen
+libdir = gpath + "/waveshare_epd"
+
+# Add it to the path
+if os.path.exists(libdir):
+    sys.path.append(libdir)
+
+import logging
+
+from waveshare_epd import epd2in7
+import time
+from PIL import Image,ImageDraw,ImageFont
+import traceback
+
+# Initialize the screen
+epd = epd2in7.EPD()
+epd.init()
+epd.Init_4Gray()
+
+# Open the provided image
+print imgpath
+image = Image.open(imgpath)
+
+# Print it to the display
+epd.display_4Gray(epd.getbuffer_4Gray(image))
+
+# Power down display
+epd.sleep()
+
+exit()


### PR DESCRIPTION

Adds a python script which displays using the 4Gray variant of commands, and converted the display and converter classes to switch between them

